### PR TITLE
Added logging

### DIFF
--- a/chess.py
+++ b/chess.py
@@ -1,12 +1,14 @@
 from chess_pieces import *
 import re
+import logging 
 
-from birdseye import eye
+logging.getLogger().setLevel(logging.DEBUG)
 
 WHITE = "White"
 BLACK = "Black"
 
 def mirror(board): 
+    logging.debug ("Flipping the board")
     # Make sure we don't change the actual board
     board = board.copy()
 
@@ -85,8 +87,8 @@ class Board:
 
         return result
 
-    @eye
     def setup(self):
+        logging.debug ("Setting up board")
         for row in self.game_board:
             for square in row:
                 if square.row == 1: square.piece = Pawn(WHITE)
@@ -108,6 +110,7 @@ class Board:
         )
         """
         origin, destination = move
+        logging.info(f"Moving piece from {origin} to {destination}")
 
         origin_square = self [origin]
         destination_square = self [destination]
@@ -118,6 +121,7 @@ class Board:
         # changing the player whose turn it is
         if self.turn == WHITE: self.turn = BLACK
         else: self.turn = WHITE
+        logging.info(f"Switching turn to {self.turn}")
 
     def move_valid(self, move):
         """
@@ -125,7 +129,6 @@ class Board:
         """
         return True  # DEBUG VALUE
 
-    @eye
     def getMove(self, move: str) -> ( (int, int), (int, int) ):
         """
         Parses move from str input.
@@ -161,6 +164,7 @@ class Board:
             letter_to_index[destination[0]]
         ) 
 
+        logging.debug(f"Move {move} interpreted as {(origin, destination)}")
         return origin, destination 
 
 def main():
@@ -185,7 +189,7 @@ def main():
             
             move = board.getMove(pinput)
             move_valid = board.move_valid(move)
-            print(move_valid)
+            logging.debug(move_valid)
             
         board.move(move)
                


### PR DESCRIPTION
Resolves #7. Also, removed birdseye as an import.

Basically, logged at these points: 

- Whenever the board is mirrored (debug)
- When the board is set up (debug)
- When a move is interpreted by `Board.getMove` (debug)
- When a move is made (info)
- When the next turn is reached (info)
- When a move is determined as valid or invalid (debug)

The log levels can be customized by including this line at the top of the file: 
`logging.getLogger().setLevel(<level>)`

Replace `<level>` with one of: 

1. `logging.CRITICAL`
2. `logging.ERROR`
3. `logging.WARNING`
4. `logging.INFO`
5. `logging.DEBUG`
6. `logging.NOTSET`

Each level of logging also logs any messages in a level above it. For example, setting the log level to `INFO` will also show `WARNING`s. The default is WARNING`, but I included a line to change it to `DEBUG` until we're production ready.